### PR TITLE
Removed level tags on course cards and aligned properly

### DIFF
--- a/components/Dashboard/CourseCard.jsx
+++ b/components/Dashboard/CourseCard.jsx
@@ -8,14 +8,13 @@ export default function CourseCard({ course, i }) {
         className="block group relative bg-white rounded-lg border border-gray-200 p-6 hover:shadow-lg transition-shadow duration-200"
       >
         <div className="flex items-center justify-between mb-4">
-          <span className="text-xs font-medium text-gray-500">{course.level}</span>
+          <h3 className="text-lg font-semibold text-gray-900">{course.title}</h3>
           <div className="h-8 w-8 rounded-full bg-gray-100 flex items-center justify-center">
             <svg className="h-4 w-4 text-gray-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
             </svg>
           </div>
         </div>
-        <h3 className="text-lg font-semibold text-gray-900 mb-2">{course.title}</h3>
         <div className="mt-4">
           <div className="flex items-center justify-between text-sm mb-1">
             <span className="text-gray-500">Progress</span>


### PR DESCRIPTION
# Remove Level Tags and Improve Course Card Layout

## Changes Made
- Removed the level tags (Beginner/Intermediate/Advanced) from course cards
- Improved the course card layout by:
  - Moving the course title to the top left
  - Keeping the arrow icon on the top right
  - Maintaining the progress bar at the bottom